### PR TITLE
#124: updated global roles table to add both Active User and Jupyterhub

### DIFF
--- a/src/components/UserProfile/MyRoles.jsx
+++ b/src/components/UserProfile/MyRoles.jsx
@@ -120,7 +120,24 @@ class MyRoles extends React.Component {
                 <OverlayTrigger
                   placement="right"
                   delay={{ show: 100, hide: 300 }}
-                  overlay={renderTooltip("fo-tooltip", "Users cannot access the Jupyterhub cluster until they are active members.")}
+                  overlay={renderTooltip("fo-tooltip", "A fully enrolled FABRIC Testbed User with all the rights and privileges therein.")}
+                >
+                  <i className="fa fa-question-circle text-secondary ml-2"></i>
+                </OverlayTrigger>
+              </td>
+              <td className="text-center">
+                {this.renderRoleTableFields(
+                  people.roles.indexOf("fabric-active-users") > -1
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Jupyterhub
+                <OverlayTrigger
+                  placement="right"
+                  delay={{ show: 100, hide: 300 }}
+                  overlay={renderTooltip("fo-tooltip", "Provides access to the Jupyterhub cluster. User must be a member of at least one project to maintain this access.")}
                 >
                   <i className="fa fa-question-circle text-secondary ml-2"></i>
                 </OverlayTrigger>


### PR DESCRIPTION
- added two more rows in the Global Roles table: Active User and Jupyerhub.
