### PR TITLE
Feature/manage slices by project

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -129,7 +129,7 @@ class App extends React.Component {
             <Route path="/resources" component={Resources} />
             <Route path="/help" component={Help} />
             <ProtectedRoute path="/slices/:slice_id,:project_id" component={SliceViewer} />
-            <ProtectedRoute path="/new-slice" component={NewSliceForm} />
+            <ProtectedRoute path="/new-slice/:project_id" component={NewSliceForm} />
             <ProtectedRoute path="/projects/:id" component={ProjectForm} />
             <ProtectedRoute path="/experiments" component={Experiments} />
             <ProtectedRoute path="/users/:id" component={PublicUserProfile} />

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,6 @@ import { getActiveMaintenanceNotice } from "./services/announcementService.js";
 import { default as portalData } from "./services/portalData.json";
 import Home from "./pages/Home";
 import Resources from "./pages/Resources";
-import Projects from "./pages/Projects";
 import ProjectForm from "./pages/ProjectForm";
 import Signup from "./pages/static/Signup";
 import AUP from "./pages/static/AUP";
@@ -132,7 +131,6 @@ class App extends React.Component {
             <ProtectedRoute path="/slices/:slice_id,:project_id" component={SliceViewer} />
             <ProtectedRoute path="/new-slice" component={NewSliceForm} />
             <ProtectedRoute path="/projects/:id" component={ProjectForm} />
-            <ProtectedRoute path="/projects" component={Projects} />
             <ProtectedRoute path="/experiments" component={Experiments} />
             <ProtectedRoute path="/users/:id" component={PublicUserProfile} />
             <ProtectedRoute path="/user" component={User} />

--- a/src/components/Experiment/Projects.jsx
+++ b/src/components/Experiment/Projects.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import SpinnerWithText from "../components/common/SpinnerWithText";
-import Pagination from "../components/common/Pagination";
-import ProjectsTable from "../components/Project/ProjectsTable";
-import RadioBtnGroup from "../components/common/RadioBtnGroup";
-import { getCurrentUser } from "../services/peopleService.js";
-import { getProjects } from "../services/projectService.js";
-import { default as portalData } from "../services/portalData.json";
-import checkGlobalRoles from "../utils/checkGlobalRoles"; 
-import toLocaleTime from "../utils/toLocaleTime";
+import SpinnerWithText from "../common/SpinnerWithText";
+import Pagination from "../common/Pagination";
+import ProjectsTable from "../Project/ProjectsTable";
+import RadioBtnGroup from "../common/RadioBtnGroup";
+import { getCurrentUser } from "../../services/peopleService.js";
+import { getProjects } from "../../services/projectService.js";
+import { default as portalData } from "../../services/portalData.json";
+import checkGlobalRoles from "../../utils/checkGlobalRoles"; 
+import toLocaleTime from "../../utils/toLocaleTime";
 import { toast } from "react-toastify";
 
 class Projects extends React.Component {
@@ -135,7 +135,7 @@ class Projects extends React.Component {
       projectsCount, searchQuery } = this.state;
 
     return (
-      <div className="container">
+      <div className="col-9">
         <div className="d-flex flex-row justify-content-between">
           <div className="d-flex flex-row">
             <h1>Projects</h1>

--- a/src/components/Experiment/Slices.jsx
+++ b/src/components/Experiment/Slices.jsx
@@ -36,18 +36,26 @@ class Slices extends React.Component {
   async componentDidMount() {
     // Show loading spinner and when waiting API response
     this.setState({ showSpinner: true });
-
-    // call PR first to check if the user has project.
     try {
-      const { data: res } = await getProjects("myProjects", 0, 200);
-      if (res.results.length === 0) {
-        this.setState({ hasProject: false, showSpinner: false });
+      if (window.location.href.includes("/projects")) {
+        // call credential manager to generate tokens
+        autoCreateTokens("all").then(async () => {
+          const { data: res } = await getSlices();
+          const slices = res.data.filter(s => s.project_id === this.props.projectId);
+          this.setState({ slices, showSpinner: false });
+        });
       } else {
-      // call credential manager to generate tokens
-      autoCreateTokens("all").then(async () => {
-        const { data: res } = await getSlices();
-        this.setState({ slices: res.data, showSpinner: false });
-      });
+        // call PR first to check if the user has project.
+        const { data: res } = await getProjects("myProjects", 0, 200);
+        if (res.results.length === 0) {
+          this.setState({ hasProject: false, showSpinner: false });
+        } else {
+        // call credential manager to generate tokens
+        autoCreateTokens("all").then(async () => {
+            const { data: res } = await getSlices();
+            this.setState({ slices: res.data, showSpinner: false });
+          });
+        }
       }
     } catch (err) {
       toast.error("Failed to get slices. Please re-login and try again.");
@@ -88,12 +96,7 @@ class Slices extends React.Component {
 
     // filter -> sort -> paginate
     let filtered = allSlices;
-
-    // if the UI is under Project tab, filter only slices under this project.
-    if (this.props.parent === "Project") {
-      filtered = allSlices.filter(s => s.project_id === this.props.projectId);
-    }
-
+    
     const filterMap = {
       "Name": "name",
       "ID": "slice_id",
@@ -153,7 +156,7 @@ class Slices extends React.Component {
           !showSpinner && hasProject && slices.length === 0 && 
           <div>
             {
-              this.props.parent === "Projects" &&
+              this.props.parent === "Projects" ?
               <div>
                 <div className="d-flex flex-row">
                   <Link to={`/new-slice/${this.props.projectId}`} className="btn btn-primary mr-4">
@@ -170,7 +173,7 @@ class Slices extends React.Component {
                 </div>
                 <div className="alert alert-warning mt-3" role="alert">
                   <p className="mt-2">
-                    You have no slice under this project. Please create slices in Portal or &nbsp;
+                    You have no slice in this project. Please create slices in Portal or &nbsp;
                     <a
                     href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
                     target="_blank"
@@ -187,27 +190,27 @@ class Slices extends React.Component {
                     </ul>
                   </p>
                 </div>
-              </div>
+              </div> :
+              <div className="alert alert-warning mt-3" role="alert">
+                  <p className="mt-2">
+                    We couldn't find your slice. Please create slices in Portal or &nbsp;
+                    <a
+                    href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
+                    target="_blank"
+                    rel="noreferrer"
+                    >JupyterHub</a> first. Here are some guide articles you may find helpful:
+                  </p>
+                  <p>
+                    <ul>
+                      <li><a href={portalData.learnArticles.guideToSliceBuilder} target="_blank" rel="noreferrer">Portal Slice Builder User Guide</a></li>
+                      <li><a href={portalData.learnArticles.guideToStartExperiment} target="_blank" rel="noreferrer">Start Your First Experiment</a></li>
+                      <li><a href={portalData.learnArticles.guideToInstallPythonAPI} target="_blank" rel="noreferrer">Install the FABRIC Python API</a></li>
+                      <li><a href={portalData.learnArticles.guideToSliceManager} target="_blank" rel="noreferrer">Slice Manager</a></li>
+                      <li><a href={portalData.learnArticles.guideToSliceEditor} target="_blank" rel="noreferrer">Slice Editor</a></li>
+                    </ul>
+                  </p>
+                </div>
             }
-            <div className="alert alert-warning mt-3" role="alert">
-              <p className="mt-2">
-                We couldn't find your slice. Please create slices in Portal or &nbsp;
-                <a
-                href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
-                target="_blank"
-                rel="noreferrer"
-                >JupyterHub</a> first. Here are some guide articles you may find helpful:
-              </p>
-              <p>
-                <ul>
-                  <li><a href={portalData.learnArticles.guideToSliceBuilder} target="_blank" rel="noreferrer">Portal Slice Builder User Guide</a></li>
-                  <li><a href={portalData.learnArticles.guideToStartExperiment} target="_blank" rel="noreferrer">Start Your First Experiment</a></li>
-                  <li><a href={portalData.learnArticles.guideToInstallPythonAPI} target="_blank" rel="noreferrer">Install the FABRIC Python API</a></li>
-                  <li><a href={portalData.learnArticles.guideToSliceManager} target="_blank" rel="noreferrer">Slice Manager</a></li>
-                  <li><a href={portalData.learnArticles.guideToSliceEditor} target="_blank" rel="noreferrer">Slice Editor</a></li>
-                </ul>
-              </p>
-            </div>
           </div>
         }
         {

--- a/src/components/Experiment/Slices.jsx
+++ b/src/components/Experiment/Slices.jsx
@@ -173,7 +173,7 @@ class Slices extends React.Component {
                 </div>
                 <div className="alert alert-warning mt-3" role="alert">
                   <p className="mt-2">
-                    You have no slice in this project. Please create slices in Portal or &nbsp;
+                    You have no slice in this project. Please create slices in Portal or&nbsp;
                     <a
                     href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
                     target="_blank"

--- a/src/components/Experiment/Slices.jsx
+++ b/src/components/Experiment/Slices.jsx
@@ -117,7 +117,7 @@ class Slices extends React.Component {
     const { totalCount, data } = this.getPageData();
 
     return (
-      <div className="col-9">
+      <div className={this.props.styleProp}>
         <h1>Slices</h1>
         {
           showSpinner && <SpinnerWithText text={"Loading slices..."} />
@@ -143,23 +143,25 @@ class Slices extends React.Component {
         {
           !showSpinner && hasProject && slices.length === 0 && 
           <div>
-            <div className="d-flex flex-row">
-              <Link to="/new-slice" className="btn btn-primary mr-4">
-                Create Slice in Portal
-              </Link>
-              <a
-                href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
-                className="btn btn-primary"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Create Slice in JupyterHub
-              </a>
-            </div>
+            {
+              this.props.parent === "Projects" &&
+                <div className="d-flex flex-row">
+                  <Link to="/new-slice" className="btn btn-primary mr-4">
+                    Create Slice in Portal
+                  </Link>
+                  <a
+                    href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
+                    className="btn btn-primary"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Create Slice in JupyterHub
+                  </a>
+                </div>
+            }
             <div className="alert alert-warning mt-3" role="alert">
               <p className="mt-2">
-                We couldn't find your slice. Please create slices in&nbsp;
-                <Link to="/new-slice">Portal</Link> or &nbsp;
+                We couldn't find your slice. Please create slices in Portal or &nbsp;
                 <a
                 href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
                 target="_blank"
@@ -190,9 +192,12 @@ class Slices extends React.Component {
                 onInputChange={this.handleSearch}
                 className="my-0"
               />
-              <Link to="/new-slice" className="btn btn-primary create-project-btn">
-                Create Slice
-              </Link>
+              {
+                this.props.parent === "Projects" &&
+                <Link to="/new-slice" className="btn btn-primary create-project-btn">
+                  Create Slice
+                </Link>
+              }
             </div>
             <div className="my-2 d-flex flex-row justify-content-between">
               <span>Showing {totalCount} slices.</span>

--- a/src/components/Experiment/Slices.jsx
+++ b/src/components/Experiment/Slices.jsx
@@ -89,6 +89,11 @@ class Slices extends React.Component {
     // filter -> sort -> paginate
     let filtered = allSlices;
 
+    // if the UI is under Project tab, filter only slices under this project.
+    if (this.props.parent === "Project") {
+      filtered = allSlices.filter(s => s.project_id === this.props.projectId);
+    }
+
     const filterMap = {
       "Name": "name",
       "ID": "slice_id",
@@ -118,7 +123,11 @@ class Slices extends React.Component {
 
     return (
       <div className={this.props.styleProp}>
-        <h1>Slices</h1>
+        {
+          this.props.parent === "Projects" ?
+            <h2>Project Slices</h2> : <h1>Slices</h1>
+        }
+        
         {
           showSpinner && <SpinnerWithText text={"Loading slices..."} />
         }
@@ -145,6 +154,7 @@ class Slices extends React.Component {
           <div>
             {
               this.props.parent === "Projects" &&
+              <div>
                 <div className="d-flex flex-row">
                   <Link to="/new-slice" className="btn btn-primary mr-4">
                     Create Slice in Portal
@@ -158,6 +168,26 @@ class Slices extends React.Component {
                     Create Slice in JupyterHub
                   </a>
                 </div>
+                <div className="alert alert-warning mt-3" role="alert">
+                  <p className="mt-2">
+                    You have no slice under this project. Please create slices in Portal or &nbsp;
+                    <a
+                    href={this.jupyterLinkMap[checkPortalType(window.location.href)]}
+                    target="_blank"
+                    rel="noreferrer"
+                    >JupyterHub</a> first. Here are some guide articles you may find helpful:
+                  </p>
+                  <p>
+                    <ul>
+                      <li><a href={portalData.learnArticles.guideToSliceBuilder} target="_blank" rel="noreferrer">Portal Slice Builder User Guide</a></li>
+                      <li><a href={portalData.learnArticles.guideToStartExperiment} target="_blank" rel="noreferrer">Start Your First Experiment</a></li>
+                      <li><a href={portalData.learnArticles.guideToInstallPythonAPI} target="_blank" rel="noreferrer">Install the FABRIC Python API</a></li>
+                      <li><a href={portalData.learnArticles.guideToSliceManager} target="_blank" rel="noreferrer">Slice Manager</a></li>
+                      <li><a href={portalData.learnArticles.guideToSliceEditor} target="_blank" rel="noreferrer">Slice Editor</a></li>
+                    </ul>
+                  </p>
+                </div>
+              </div>
             }
             <div className="alert alert-warning mt-3" role="alert">
               <p className="mt-2">
@@ -212,6 +242,7 @@ class Slices extends React.Component {
               slices={data}
               sortColumn={sortColumn}
               onSort={this.handleSort}
+              parent={this.props.parent}
             />
             <Pagination
               itemsCount={totalCount}

--- a/src/components/Experiment/Slices.jsx
+++ b/src/components/Experiment/Slices.jsx
@@ -156,7 +156,7 @@ class Slices extends React.Component {
               this.props.parent === "Projects" &&
               <div>
                 <div className="d-flex flex-row">
-                  <Link to="/new-slice" className="btn btn-primary mr-4">
+                  <Link to={`/new-slice/${this.props.projectId}`} className="btn btn-primary mr-4">
                     Create Slice in Portal
                   </Link>
                   <a
@@ -224,7 +224,7 @@ class Slices extends React.Component {
               />
               {
                 this.props.parent === "Projects" &&
-                <Link to="/new-slice" className="btn btn-primary create-project-btn">
+                <Link to={`/new-slice/${this.props.projectId}`} className="btn btn-primary create-project-btn">
                   Create Slice
                 </Link>
               }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -21,12 +21,6 @@ class Header extends React.Component {
       { name: "Home", path: "/", child: [], exact: true },
       { name: "Resources", path: "/resources", child: [], exact: false },
       {
-        name: "Projects",
-        path: "/projects",
-        child: [],
-        exact: false,
-      },
-      {
         name: "Experiments",
         path: "/experiments",
         child: [],

--- a/src/components/Project/NewProjectForm.jsx
+++ b/src/components/Project/NewProjectForm.jsx
@@ -70,7 +70,7 @@ class NewProjectForm extends Form {
       let ownerIDs = addedOwners.map((user) => user.uuid);
       let memberIDs = addedMembers.map((user) => user.uuid);
       // redirect users directly to the projects page
-      this.props.history.push("/projects");
+      this.props.history.push("/experiments#projects");
       toast.info("Creation request is in process. You'll receive a message when the project is successfully created.");
       // while the async call is processing under the hood
       const  { data: res } = await createProject(data, ownerIDs, memberIDs);
@@ -80,7 +80,7 @@ class NewProjectForm extends Form {
     }
     catch (err) {
       toast.error("Failed to create project.");
-      this.props.history.push("/projects");
+      this.props.history.push("/experiments#projects");
     }
   };
 

--- a/src/components/Project/ProjectProfile.jsx
+++ b/src/components/Project/ProjectProfile.jsx
@@ -36,7 +36,7 @@ class ProjectProfile extends Component {
       <div>
         <div className="d-flex flex-row justify-content-between">
           <h1>{project.name}</h1>
-          <Link to="/projects">
+          <Link to="/experiments#projects">
             <button
               className="btn btn-sm btn-outline-primary my-3"
             >

--- a/src/components/Slice/SlicesTable.jsx
+++ b/src/components/Slice/SlicesTable.jsx
@@ -22,6 +22,13 @@ class SlicesTable extends Component {
         )
       },
       {
+        path: "project_name",
+        label: "Project",
+        content: (slice) => (
+          <Link to={`/projects/${slice.project_id}`}>{slice.project_name}</Link>
+        ),
+      },
+      {
         content: (slice) => (
           <CopyButton
             id={slice.slice_id}

--- a/src/components/Slice/SlicesTable.jsx
+++ b/src/components/Slice/SlicesTable.jsx
@@ -5,7 +5,8 @@ import CopyButton from "../common/CopyButton";
 import sliceTimeParser from "../../utils/sliceTimeParser.js";
 
 class SlicesTable extends Component {
-  columns = [
+  columns = {
+    "allSlices": [
       {
         path: "name",
         label: "Slice Name",
@@ -38,13 +39,41 @@ class SlicesTable extends Component {
           />
         ),
       },
-    ];
+    ],
+    "projectSlices": [
+      {
+        path: "name",
+        label: "Slice Name",
+        content: (slice) => (
+          <Link to={`/slices/${slice.slice_id},${slice.project_id}`}>{slice.name}</Link>
+        ),
+      },
+      { path: "state", label: "Slice State" },
+      {
+        path: "lease_end_time",
+        label: "Lease End",
+        content: (slice) => (
+          <span>{sliceTimeParser(slice.lease_end_time)}</span>
+        )
+      },
+      {
+        content: (slice) => (
+          <CopyButton
+            id={slice.slice_id}
+            text={"Slice ID"}
+            btnStyle={"btn btn-sm btn-primary"}
+            showCopiedValue={true}
+          />
+        ),
+      },
+    ]
+  };
 
   render() {
-    const { slices, onSort, sortColumn } = this.props;
+    const { slices, onSort, sortColumn, parent } = this.props;
     return (
       <Table
-        columns={this.columns}
+        columns={parent === "Projects" ? this.columns["projectSlices"] : this.columns["allSlices"]}
         data={slices}
         sortColumn={sortColumn}
         onSort={onSort}

--- a/src/components/SliceViewer/ProjectTags.jsx
+++ b/src/components/SliceViewer/ProjectTags.jsx
@@ -4,11 +4,13 @@ import { getProjectById } from "../../services/projectService.js";
 import { toast } from "react-toastify";
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { default as portalData } from "../../services/portalData.json";
+import { Link } from "react-router-dom";
 
 export default class SideLinks extends Component { 
   state = {
     showSpinner: false,
-    project: [],
+    project: {},
+    tags: [],
     tagKeyValuePairs: {
       "VM.NoLimitCPU": "allows to create VMs with more than 2 CPU cores",
       "VM.NoLimitRAM": "allows to create VMs with more than 10 GB of RAM",
@@ -36,15 +38,16 @@ export default class SideLinks extends Component {
   
   async componentDidMount() {
     try {
+      this.setState({ showSpinner: true });
       const { data: res } = await getProjectById(this.props.projectId);
-      this.setState({ project: res.results[0] });
+      this.setState({ project: res.results[0], tags: res.results[0].tags, showSpinner: false });
     } catch (err) {
       toast.error("Failed to load the project information. Please try again later.");
     }
   }
 
   render() {
-    const { project, tagKeyValuePairs, showSpinner } = this.state;
+    const { project, tags, tagKeyValuePairs, showSpinner } = this.state;
     const renderTooltip = (id, content) => (
       <Tooltip id={id}>
         {content}
@@ -53,7 +56,7 @@ export default class SideLinks extends Component {
     return(
       <div className="form-group">
       <label htmlFor="projectSelect" className="slice-form-label">
-        Project
+        Project: <Link to={`/projects/${project.uuid}`}>{project.name}</Link>
         <a
           href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
           target="_blank"
@@ -63,23 +66,18 @@ export default class SideLinks extends Component {
           Project Permissions
         </a>
       </label>
-      <select
-        id="selectSliceProject"
-        name="selectSliceProject"
-        className="form-control form-control-sm"
-        disabled
-      >
-        <option value={project.uuid}>{project.name}</option>
-      </select>
       {
         !showSpinner && <div>
           {
-            project.tags.length === 0 && <div className="sm-alert mt-2">
+
+          }
+          {
+            tags.length === 0 && <div className="sm-alert mt-2">
               This project has no permission tags. Please use only SharedNICs and L2Bridge for this slice.
             </div>
           }
           {
-            project.tags.length > 0 && <div className="mt-2">
+            tags.length > 0 && <div className="mt-2">
               { 
                 project.tags.map(tag =>
                   <OverlayTrigger

--- a/src/components/SliceViewer/ProjectTags.jsx
+++ b/src/components/SliceViewer/ProjectTags.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import SpinnerWithText from "../../components/common/SpinnerWithText";
-import { getProjects, getProjectById } from "../../services/projectService.js";
+import { getProjectById } from "../../services/projectService.js";
 import { toast } from "react-toastify";
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { default as portalData } from "../../services/portalData.json";
@@ -8,9 +8,7 @@ import { default as portalData } from "../../services/portalData.json";
 export default class SideLinks extends Component { 
   state = {
     showSpinner: false,
-    projects: [],
-    projectIdToGenerateToken: "",
-    tags: [],
+    project: [],
     tagKeyValuePairs: {
       "VM.NoLimitCPU": "allows to create VMs with more than 2 CPU cores",
       "VM.NoLimitRAM": "allows to create VMs with more than 10 GB of RAM",
@@ -38,38 +36,15 @@ export default class SideLinks extends Component {
   
   async componentDidMount() {
     try {
-      const { data: res } = await getProjects("myProjects", 0, 200);
-      this.setState({ projects: res.results });
+      const { data: res } = await getProjectById(this.props.projectId);
+      this.setState({ project: res.results[0] });
     } catch (err) {
-      toast.error("Failed to load user's projects. Please try again later.");
-    }
-  }
-
-  handleProjectChange = (e) => {
-    if (e.target.value !== "") {
-      this.setState({ projectIdToGenerateToken: e.target.value }, () => {
-        this.props.onProjectChange(this.state.projectIdToGenerateToken);
-        this.getProjectTags();
-      });
-    } else {
-      this.setState({ projectIdToGenerateToken: "", tags: [] });
-    }
-  }
-
-  async getProjectTags() {
-    this.setState({  showSpinner: true });
-    try {
-      const { data: res } = await getProjectById(this.state.projectIdToGenerateToken);
-      const project = res.results[0];
-      this.setState({ tags: project.tags, showSpinner: false});
-    } catch (err) {
-      this.setState({ showSpinner: false });
-      toast.error("Failed to load the permissions of this project. Please re-select a project.");
+      toast.error("Failed to load the project information. Please try again later.");
     }
   }
 
   render() {
-    const { projects, projectIdToGenerateToken, tags, tagKeyValuePairs, showSpinner } = this.state;
+    const { project, tagKeyValuePairs, showSpinner } = this.state;
     const renderTooltip = (id, content) => (
       <Tooltip id={id}>
         {content}
@@ -92,33 +67,21 @@ export default class SideLinks extends Component {
         id="selectSliceProject"
         name="selectSliceProject"
         className="form-control form-control-sm"
-        value={projectIdToGenerateToken}
-        onChange={this.handleProjectChange}
+        disabled
       >
-        <option value="">Choose...</option>
-        {
-          projects.length > 0 && projects.map(project => 
-            <option value={project.uuid} key={`project-${project.name}`}>{project.name}</option>
-          )
-        }
+        <option value={project.uuid}>{project.name}</option>
       </select>
       {
-        projectIdToGenerateToken === "" && 
-        <div className="sm-alert mt-2">
-          Please select a project that you want to create slice for.
-        </div>
-      }
-      {
-        projectIdToGenerateToken !== "" && ! showSpinner && <div>
+        !showSpinner && <div>
           {
-            tags.length === 0 && <div className="sm-alert mt-2">
+            project.tags.length === 0 && <div className="sm-alert mt-2">
               This project has no permission tags. Please use only SharedNICs and L2Bridge for this slice.
             </div>
           }
           {
-            tags.length > 0 && <div className="mt-2">
+            project.tags.length > 0 && <div className="mt-2">
               { 
-                tags.map(tag =>
+                project.tags.map(tag =>
                   <OverlayTrigger
                     placement="right"
                     delay={{ show: 100, hide: 300 }}

--- a/src/components/SliceViewer/ProjectTags.jsx
+++ b/src/components/SliceViewer/ProjectTags.jsx
@@ -56,28 +56,32 @@ export default class SideLinks extends Component {
     return(
       <div className="form-group">
       <label htmlFor="projectSelect" className="slice-form-label">
-        Project: <Link to={`/projects/${project.uuid}`}>{project.name}</Link>
-        <a
-          href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <i className="fa fa-question-circle mx-2"></i>
-          Project Permissions
-        </a>
+        <Link to={`/projects/${project.uuid}`}>{project.name}</Link>
       </label>
       {
         !showSpinner && <div>
           {
-
-          }
-          {
             tags.length === 0 && <div className="sm-alert mt-2">
-              This project has no permission tags. Please use only SharedNICs and L2Bridge for this slice.
+              This project has no <a
+                href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <i className="fa fa-question-circle mr-2"></i>
+                permission tags 
+              </a>. Please use only SharedNICs and L2Bridge for this slice.
             </div>
           }
           {
             tags.length > 0 && <div className="mt-2">
+              <a
+                href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <i className="fa fa-question-circle mr-2"></i>
+                Project Permission:
+              </a>
               { 
                 project.tags.map(tag =>
                   <OverlayTrigger

--- a/src/components/SliceViewer/ProjectTags.jsx
+++ b/src/components/SliceViewer/ProjectTags.jsx
@@ -54,52 +54,53 @@ export default class SideLinks extends Component {
       </Tooltip>
     ); 
     return(
-      <div className="form-group">
-      <label htmlFor="projectSelect" className="slice-form-label">
-        <Link to={`/projects/${project.uuid}`}>{project.name}</Link>
-      </label>
-      {
-        !showSpinner && <div>
-          {
-            tags.length === 0 && <div className="sm-alert mt-2">
-              This project has no <a
-                href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <i className="fa fa-question-circle mr-2"></i>
-                permission tags 
-              </a>. Please use only SharedNICs and L2Bridge for this slice.
-            </div>
-          }
-          {
-            tags.length > 0 && <div className="mt-2">
-              <a
-                href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <i className="fa fa-question-circle mr-2"></i>
-                Project Permission:
-              </a>
-              { 
-                project.tags.map(tag =>
-                  <OverlayTrigger
-                    placement="right"
-                    delay={{ show: 100, hide: 300 }}
-                    overlay={renderTooltip("pl-tooltip", tagKeyValuePairs[tag])}
-                    key={`project-tag-${tag}`}
+      <div>
+        {
+        showSpinner ? <SpinnerWithText text={"Loading project permissions..."} /> :
+        <table className="table table-sm">
+          <tbody>
+            <tr>
+              <td><b>Project</b></td>
+              <td><Link to={`/projects/${project.uuid}`}>{project.name}</Link></td>
+            </tr>
+            <tr>
+              <td>
+                <a
+                  href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <b>Permissions</b><i className="fa fa-question-circle ml-1"></i>
+                </a>
+              </td>
+              <td>
+              {
+                tags.length === 0 ? <span>
+                  This project has no <a
+                    href={`${portalData.learnArticles.guideToProjectPermissions}#project-permissions`}
+                    target="_blank"
+                    rel="noreferrer"
                   >
-                    <span className="badge badge-primary mr-2 project-tag">{tag}</span>
-                  </OverlayTrigger>
-              )}
-            </div>
-          }
-        </div>
-      }
-      {
-        showSpinner && <SpinnerWithText text={"Loading project permissions..."} />
-      }
+                    <i className="fa fa-question-circle mr-2"></i>
+                    permission tags 
+                  </a>. Please use only SharedNICs and L2Bridge for this slice.
+                </span> : 
+                tags.map(tag =>
+                    <OverlayTrigger
+                      placement="right"
+                      delay={{ show: 100, hide: 300 }}
+                      overlay={renderTooltip("pl-tooltip", tagKeyValuePairs[tag])}
+                      key={`project-tag-${tag}`}
+                    >
+                      <span className="badge badge-primary mr-2 project-tag">{tag}</span>
+                    </OverlayTrigger>
+                )
+              }
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        }
     </div>
     )
   }

--- a/src/components/SliceViewer/SingleComponent.jsx
+++ b/src/components/SliceViewer/SingleComponent.jsx
@@ -99,6 +99,7 @@ export default class SingleComponent extends Component {
                   type="text" className="form-control form-control-sm" id="inputComponentName"
                   value={componentName}
                   onChange={this.handleComponentNameChange}
+                  placeholder={"at least 2 characters..."}
                 />
               </div>
               <div className="form-group slice-builder-form-group col-md-4">

--- a/src/pages/Experiments.jsx
+++ b/src/pages/Experiments.jsx
@@ -1,34 +1,38 @@
 import React from "react";
 import SideNav from "../components/common/SideNav";
 import Slices from "../components/Experiment/Slices";
+import Projects from "../components/Experiment/Projects";
 import Tokens from "../components/Experiment/Tokens";
 import Keys from "../components/Experiment/Keys";
 
 class Experiments extends React.Component {
   state = {
     SideNavItems: [
-      { name: "MY SLICES", active: true },
+      { name: "PROJECTS & SLICES", active: true },
+      { name: "MY SLICES", active: false },
       { name: "MANAGE TOKENS", active: false },
       { name: "MANAGE SSH KEYS", active: false },
     ],
     user: {},
     people: {},
     activeIndex: 0,
-    componentNames: [Slices, Tokens, Keys],
+    componentNames: [Projects, Slices, Tokens, Keys],
   };
 
   async componentDidMount() {
     // url anchor: #slices, #tokens, #sshKeys
     const hash = this.props.location.hash;
     const activeMap = {
-      "#slices": 0,
-      "#tokens": 1,
-      "#sshKeys": 2,
+      "#projects": 0,
+      "#slices": 1,
+      "#tokens": 2,
+      "#sshKeys": 3,
     }
 
     if (hash) {
       this.setState({ activeIndex: activeMap[hash] });
       this.setState({ SideNavItems: [
+        { name: "PROJECTS & SLICES", active: hash === "#projects" },
         { name: "MY SLICES", active: hash === "#slices" },
         { name: "MANAGE TOKENS", active: hash === "#tokens" },
         { name: "MANAGE SSH KEYS", active: hash === "#sshKeys" },
@@ -38,9 +42,10 @@ class Experiments extends React.Component {
 
   handleChange = (newIndex) => {
     const indexToHash = {
-      0: "#slices",
-      1: "#tokens",
-      2: "#sshKeys",
+      0: "#projects",
+      1: "#slices",
+      2: "#tokens",
+      3: "#sshKeys",
     }
     this.setState({ activeIndex: newIndex });
     this.props.history.push(`/experiments${indexToHash[newIndex]}`);

--- a/src/pages/Experiments.jsx
+++ b/src/pages/Experiments.jsx
@@ -64,6 +64,7 @@ class Experiments extends React.Component {
           <TagName
             user={this.state.user}
             people={this.state.people}
+            styleProp={"col-9"}
           />
         </div>
       </div>

--- a/src/pages/NewSliceForm.jsx
+++ b/src/pages/NewSliceForm.jsx
@@ -322,14 +322,14 @@ class NewSliceForm extends React.Component {
 
     try {
       // re-create token using user's choice of project
+      const project_id = this.state.projectIdToGenerateToken;
       autoCreateTokens(this.state.projectIdToGenerateToken).then(async () => {
         try {
           const { data: res } = await createSlice(requestData);
           toast.success("Slice created successfully.");
           // redirect users directly to the new slice page
           const slice_id = res.data[0].slice_id;
-          // this.props.history.push("/experiments#slices");
-          this.props.history.push(`/slices/${slice_id}`)
+          this.props.history.push(`/slices/${slice_id},${project_id}`);
         } catch (ex) {
           toast.error("Failed to create slice.");
           that.setState({ showSliceSpinner: false });

--- a/src/pages/NewSliceForm.jsx
+++ b/src/pages/NewSliceForm.jsx
@@ -379,12 +379,12 @@ class NewSliceForm extends React.Component {
                   User Guide
                 </a>
               </div>
-              <Link to="/experiments#slices" className="align-self-end mr-5">
+              <Link to={`/projects/${this.props.match.params.project_id}`} className="align-self-end mr-5">
                 <button
                   className="btn btn-sm btn-outline-primary my-3"
                 >
                   <i className="fa fa-sign-in mr-2"></i>
-                  Back to Slice List
+                  Back to Project
                 </button>
               </Link>
             </div>

--- a/src/pages/NewSliceForm.jsx
+++ b/src/pages/NewSliceForm.jsx
@@ -34,7 +34,6 @@ class NewSliceForm extends React.Component {
     showKeySpinner: false,
     showSliceSpinner: false,
     sliverKeys: [],
-    projectIdToGenerateToken: "",
     graphID: "",
     sliceNodes: [],
     sliceLinks: [],
@@ -55,7 +54,6 @@ class NewSliceForm extends React.Component {
       const { data: keys } = await getActiveKeys();
       const parsedObj = sitesParser(resources.data[0], sitesNameMapping.acronymToShortName);
       this.setState({
-        projectIdToGenerateToken: this.props.match.params.project_id,
         parsedResources: parsedObj,
         showResourceSpinner: false,
         showKeySpinner: false,
@@ -319,8 +317,8 @@ class NewSliceForm extends React.Component {
 
     try {
       // re-create token using user's choice of project
-      const project_id = this.state.projectIdToGenerateToken;
-      autoCreateTokens(this.state.projectIdToGenerateToken).then(async () => {
+      const project_id = this.props.match.params.project_id;
+      autoCreateTokens(project_id).then(async () => {
         try {
           const { data: res } = await createSlice(requestData);
           toast.success("Slice created successfully.");
@@ -338,12 +336,12 @@ class NewSliceForm extends React.Component {
   };
 
   render() {
-    const { sliceName, projectIdToGenerateToken, sshKey, sliverKeys, selectedData,
+    const { sliceName, sshKey, sliverKeys, selectedData,
       showKeySpinner, showResourceSpinner, showSliceSpinner, parsedResources,
       sliceNodes, sliceLinks, selectedCPs }
     = this.state;
 
-    const validationResult = validator.validateSlice(sliceName, sshKey, projectIdToGenerateToken, sliceNodes);
+    const validationResult = validator.validateSlice(sliceName, sshKey, sliceNodes);
 
     const renderTooltip = (id, content) => (
       <Tooltip id={id}>
@@ -407,7 +405,7 @@ class NewSliceForm extends React.Component {
                     </div>
                     <div>
                       <div className="card-body slice-builder-card-body">
-                        <ProjectTags projectId={projectIdToGenerateToken} />
+                        <ProjectTags projectId={this.props.match.params.project_id} />
                       </div>
                     </div>
                   </div>

--- a/src/pages/NewSliceForm.jsx
+++ b/src/pages/NewSliceForm.jsx
@@ -54,7 +54,8 @@ class NewSliceForm extends React.Component {
       const { data: resources } = await getResources();
       const { data: keys } = await getActiveKeys();
       const parsedObj = sitesParser(resources.data[0], sitesNameMapping.acronymToShortName);
-      this.setState({ 
+      this.setState({
+        projectIdToGenerateToken: this.props.match.params.project_id,
         parsedResources: parsedObj,
         showResourceSpinner: false,
         showKeySpinner: false,
@@ -90,10 +91,6 @@ class NewSliceForm extends React.Component {
       this.setState({ showKeySpinner: false });
       toast.error("Failed to refresh keys. Please try again later.");
     }
-  }
-
-  handleProjectChange = (uuid) => {
-    this.setState({ projectIdToGenerateToken: uuid });
   }
 
   handleSliceNameChange = (e) => {
@@ -404,13 +401,13 @@ class NewSliceForm extends React.Component {
                       rel="noreferrer"
                     >
                       <button className="btn btn-link">
-                        Step 1: Select Project
+                        Step 1: View Project Permissions
                       </button>
                     </a>
                     </div>
                     <div>
                       <div className="card-body slice-builder-card-body">
-                        <ProjectTags onProjectChange={this.handleProjectChange} />
+                        <ProjectTags projectId={projectIdToGenerateToken} />
                       </div>
                     </div>
                   </div>

--- a/src/pages/ProjectForm.jsx
+++ b/src/pages/ProjectForm.jsx
@@ -14,6 +14,7 @@ import { getCurrentUser } from "../services/peopleService.js";
 import { updateProjectPersonnel } from "../services/projectService";
 import checkGlobalRoles from "../utils/checkGlobalRoles"; 
 import SpinnerFullPage from "../components/common/SpinnerFullPage";
+import Slices from "../components/Experiment/Slices";
 
 import {
   getProjectById,
@@ -68,6 +69,7 @@ class projectForm extends Form {
       { name: "BASIC INFORMATION", active: true },
       { name: "PROJECT OWNERS", active: false },
       { name: "PROJECT MEMBERS", active: false },
+      { name: "SLICES", active: false },
     ],
     originalProjectName: "",
     owners: [],
@@ -499,6 +501,19 @@ class projectForm extends Form {
                   users={members}
                   onSinglePersonnelUpdate={this.handleSinglePersonnelUpdate}
                   onPersonnelUpdate={this.handlePersonnelUpdate}
+                />
+              </div>
+            </div>
+            <div
+              className={`${
+                activeIndex !== 3
+                  ? "d-none"
+                  : "col-9 d-flex flex-row"
+              }`}
+            >
+              <div className="w-100">
+                <Slices
+                  parent="Projects"
                 />
               </div>
             </div>

--- a/src/pages/ProjectForm.jsx
+++ b/src/pages/ProjectForm.jsx
@@ -150,7 +150,7 @@ class projectForm extends Form {
       this.setState({ user: res2.results[0], globalRoles: checkGlobalRoles(res2.results[0]) });
     } catch (err) {
       toast.error("User's credential is expired. Please re-login.");
-      this.props.history.push("/projects");
+      this.props.history.push("/experiments#projects");
     }
 
     try {
@@ -262,7 +262,7 @@ class projectForm extends Form {
   handleDeleteProject = async (project) => {
     try {
       // redirect users directly to the projects page
-      this.props.history.push("/projects");
+      this.props.history.push("/experiments#projects");
       toast.info("Deletion request is in process. You'll receive a message when the project is successfully deleted.")
       // while the async call is processing under the hood
       await deleteProject(project.uuid);
@@ -270,7 +270,7 @@ class projectForm extends Form {
       toast.success("Project deleted successfully.");
     } catch (err) {
       toast.error("Failed to delete project.");
-      this.props.history.push("/projects");
+      this.props.history.push("/experiments#projects");
     }
   };
 
@@ -403,7 +403,7 @@ class projectForm extends Form {
                   <i className="fa fa-sign-in mr-2"></i>
                   Request Storage
                 </button>
-                <Link to="/projects">
+                <Link to="/experiments#projects">
                   <button
                     className="btn btn-sm btn-outline-primary my-3"
                   >
@@ -413,7 +413,7 @@ class projectForm extends Form {
                 </Link>
               </div>
               :
-              <Link to="/projects">
+              <Link to="/experiments#projects">
                 <button
                   className="btn btn-sm btn-outline-primary my-3"
                 >
@@ -514,6 +514,7 @@ class projectForm extends Form {
               <div className="w-100">
                 <Slices
                   parent="Projects"
+                  projectId={data.uuid}
                 />
               </div>
             </div>

--- a/src/pages/SliceViewer.jsx
+++ b/src/pages/SliceViewer.jsx
@@ -111,7 +111,7 @@ export default class SliceViewer extends Component {
           <div className="mx-5 mb-4 slice-viewer-container">
             <div className="d-flex flex-row justify-content-between align-items-center mt-2">
               <div className="d-flex flex-row justify-content-between align-items-center">
-                <h2 className="mr-4">
+                <h2 className="mr-3">
                   <b>{slice.name}</b>
                   <span className={`badge badge-${stateColors[slice.state]} ml-2`}>
                     {slice.state}
@@ -126,10 +126,12 @@ export default class SliceViewer extends Component {
                   </a>
                 </h2>
                 <h4>
-                  <span className="badge badge-light font-weight-normal p-2 mt-1">Lease End: {sliceTimeParser(slice.lease_end_time)}</span>
+                  <span className="badge badge-light font-weight-normal p-2 mt-1 mr-3">Lease End: {sliceTimeParser(slice.lease_end_time)}</span>
                 </h4>
                 <h4>
-                  Project: <Link to={`/projects/${slice.project_id}`}>{slice.project_name}</Link>
+                  <span className="badge badge-light font-weight-normal p-2 mt-1">
+                    Project: <Link to={`/projects/${slice.project_id}`}>{slice.project_name}</Link>
+                  </span>
                 </h4>
               </div>
               <div className="d-flex flex-row justify-content-between align-items-center">

--- a/src/pages/SliceViewer.jsx
+++ b/src/pages/SliceViewer.jsx
@@ -126,7 +126,10 @@ export default class SliceViewer extends Component {
                   </a>
                 </h2>
                 <h4>
-                  <span className="badge badge-light font-weight-normal p-2 mt-1">Lease End Time: {sliceTimeParser(slice.lease_end_time)}</span>
+                  <span className="badge badge-light font-weight-normal p-2 mt-1">Lease End: {sliceTimeParser(slice.lease_end_time)}</span>
+                </h4>
+                <h4>
+                  Project: <Link to={`/projects/${slice.project_id}`}>{slice.project_name}</Link>
                 </h4>
               </div>
               <div className="d-flex flex-row justify-content-between align-items-center">

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -4,6 +4,7 @@ import SpinnerFullPage from "../components/common/SpinnerFullPage";
 import MyRoles from "../components/UserProfile/MyRoles";
 import MyProfile from "../components/UserProfile/MyProfile";
 import KeyTabs from "../components/SshKey/KeyTabs";
+import Slices from "../components/Experiment/Slices";
 import { toast } from "react-toastify";
 import { getCurrentUser, getWhoAmI } from "../services/peopleService.js";
 import { getActiveKeys } from "../services/sshKeyService";
@@ -14,10 +15,11 @@ class User extends React.Component {
       { name: "MY PROFILE", active: true },
       { name: "MY ROLES & PROJECTS", active: false },
       { name: "MY SSH KEYS", active: false },
+      { name: "MY SLICES", active: false },
     ],
     user: {},
     activeIndex: 0,
-    componentNames: [MyProfile, MyRoles, KeyTabs],
+    componentNames: [MyProfile, MyRoles, KeyTabs, Slices],
     keys: [],
     showFullPageSpinner: false,
   };

--- a/src/utils/sliceValidator.js
+++ b/src/utils/sliceValidator.js
@@ -7,7 +7,7 @@ const isPositiveInteger = (input) => {
   return Number.isInteger(num) && num > 0;
 }
 
-const validateSlice = (sliceName, sshKey, projectIdToGenerateToken, sliceNodes) => {
+const validateSlice = (sliceName, sshKey, sliceNodes) => {
   const validationResult = {
     isValid: false,
     message: "",
@@ -22,12 +22,6 @@ const validateSlice = (sliceName, sshKey, projectIdToGenerateToken, sliceNodes) 
   if (sshKey === "") {
     validationResult.isValid = false;
     validationResult.message = "Please select a sliver key.";
-    return validationResult;
-  }
-
-  if (projectIdToGenerateToken === "") {
-    validationResult.isValid = false;
-    validationResult.message = "Please select a project.";
     return validationResult;
   }
 


### PR DESCRIPTION
- Merged Projects page to Experiments page and added My Slices tab to User Profile page;
- Added Slices tab on Project detail page (the only place for “Create Slice” button); updated Slice Builder “STEP 1: Select Project” to “STEP 1: View Project Permissions” and display the project name/ link/ permission tags directly;
- Added column of project name/ link to Slices table (for slices from all projects, Experiments → My Slices and User Profile → My Slices);
- Updated Slice Viewer with addition of project name and link on top.